### PR TITLE
Add Forward Proxy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,82 @@
-Forward Proxy
+Auto Managed Instance Group
 ===
 
-This terraform module manages a MIG of compute instances running an HTTP
-forward proxy.  The intended use case is to direct traffic through an
-interconnect from an on-prem data center.
+This terraform module manages a regional instance group with auto healing and
+auto scaling enabled.  The intended purpose as a generic, re-usable starting
+point for network services.  This module has been used to implement multinic
+ECMP IP routing and an HTTP forward proxy.
+
+The common bits have been extracted out.  The idea is you need only pass in a
+basic shell script to setup whatever network service you need.  For example,
+the forward proxy is a fairly simple shell script passed into the generic
+module:
+
+<details><summary>forward proxy</summary>
+<p>
+
+```
+#! /bin/bash
+#
+# Configure Apache 2 as a forward proxy
+
+apt -qq -y update
+apt -qq -y install apache2
+
+cat <<EOF >/etc/apache2/mods-available/proxy.conf
+<IfModule mod_proxy.c>
+Listen 3128
+ProxyRequests On
+<Proxy *>
+  AddDefaultCharset off
+  # This is an open proxy.  Control access with the VPC firewall.
+  # Require local
+</Proxy>
+
+# Enable the handling of HTTP/1.1 "Via:" headers
+ProxyVia On
+</IfModule>
+EOF
+
+# For the health check
+echo OK | tee /var/www/html/healthz
+
+a2enmod proxy
+a2enmod proxy_http
+a2enmod proxy_balancer
+a2enmod lbmethod_byrequests
+
+sudo systemctl enable apache2
+sudo systemctl restart apache2
+```
+
+</p>
+</details>
+
+Health Checks
+==
+
+There are two types of health checks configured to handle the two use cases of
+auto healing and taking an instance out of service.
+
+ 1. Managed Instance Group auto-healing checks.
+ 2. Load Balancing traffic distribution checks.
+
+The MIG auto-healing health checks will come into nic0.  Stop the `hc-traffic`
+service unit file to take the instance out of rotation.
+
+A basic HTTP server is included for health and traffic checking.  Replace the
+health check port and path with your workloads health check endpoint for more
+robust health checking of the workload.
+
+Helper Scripts
+==
+
+Helper scripts are included in the [scripts](scripts/) directory.
+
+`rolling_update`
+---
+
+Use this script after applying changes to the instance template used by the
+managed instance group.  The helper script performs a [Rolling
+Update][rolling-update] which replaces each instance in the vpc-link group with
+a new instance.

--- a/examples/proxy/README.md
+++ b/examples/proxy/README.md
@@ -1,0 +1,5 @@
+Forward Proxy Example
+===
+
+This example builds upon the basic example by adding a custom startup script
+which configures a forward http proxy on each instance.

--- a/examples/proxy/files/startup.sh
+++ b/examples/proxy/files/startup.sh
@@ -1,0 +1,32 @@
+#! /bin/bash
+#
+# Configure Apache 2 as a forward proxy
+
+apt -qq -y update
+apt -qq -y install apache2
+
+cat <<EOF >/etc/apache2/mods-available/proxy.conf
+<IfModule mod_proxy.c>
+Listen 3128
+ProxyRequests On
+<Proxy *>
+  AddDefaultCharset off
+  # This is an open proxy.  Control access with the VPC firewall.
+  # Require local
+</Proxy>
+
+# Enable the handling of HTTP/1.1 "Via:" headers
+ProxyVia On
+</IfModule>
+EOF
+
+# For the health check
+echo OK | tee /var/www/html/healthz
+
+a2enmod proxy
+a2enmod proxy_http
+a2enmod proxy_balancer
+a2enmod lbmethod_byrequests
+
+sudo systemctl enable apache2
+sudo systemctl restart apache2

--- a/examples/proxy/main.tf
+++ b/examples/proxy/main.tf
@@ -1,0 +1,38 @@
+# Copyright 2020 Open Infrastructure Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+# Manage the regional MIG formation
+module "proxy" {
+  source = "../../modules/55_auto"
+
+  name_prefix   = "proxy"
+  num_instances = 1
+
+  project_id   = var.project_id
+  nic0_project = var.project_id
+  nic0_network = "default"
+  nic0_subnet  = "default"
+  region       = "us-west1"
+
+  # Configure Apache2 as a forward http proxy on 3128
+  startup_script    = file("${path.module}/files/startup.sh")
+  health_check_port = 3128
+  health_check_path = "/healthz"
+
+  service_account_email = "${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+}

--- a/examples/proxy/variables.tf
+++ b/examples/proxy/variables.tf
@@ -1,0 +1,18 @@
+# Copyright 2021 Open Infrastructure Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  description = "Project ID containing managed resources"
+  type        = string
+}

--- a/modules/50_mig/files/startup.sh
+++ b/modules/50_mig/files/startup.sh
@@ -92,6 +92,8 @@ setup_status_api() {
   echo '{status: "OK", host: "'"${HOSTNAME}"'"}' > "${status_file}"
   install -v -o 0 -g 0 -m 0755 -d /var/lib/status
   install -v -o 0 -g 0 -m 0644 "${status_file}" /var/lib/status/status.json
+  install -v -o 0 -g 0 -m 0644 "${status_file}" /var/lib/status/healthz
+  install -v -o 0 -g 0 -m 0644 "${status_file}" /var/lib/status/healthz.json
 
   status_unit1="$(mktemp)"
   cat <<EOF >"${status_unit1}"

--- a/modules/55_auto/main.tf
+++ b/modules/55_auto/main.tf
@@ -66,8 +66,8 @@ resource google_compute_health_check "health" {
   unhealthy_threshold = 3
 
   http_health_check {
-    port         = 9000
-    request_path = "/status.json"
+    port         = var.health_check_port
+    request_path = var.health_check_path
   }
 }
 

--- a/modules/55_auto/variables.tf
+++ b/modules/55_auto/variables.tf
@@ -115,3 +115,15 @@ variable "startup_script" {
   type        = string
   default     = ""
 }
+
+variable "health_check_port" {
+  description = "The port for health checks, typically the port of the workload service"
+  type        = number
+  default     = 9000
+}
+
+variable "health_check_path" {
+  description = "The path for health checks, typically /healthz or something equivalent"
+  type        = string
+  default     = "/healthz"
+}

--- a/scripts/rolling_update
+++ b/scripts/rolling_update
@@ -1,0 +1,29 @@
+#! /bin/bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Start a rolling update to the latest version of the template.
+
+if [[ -z "${1:-}" ]]; then
+  echo "Usage: $0 INSTANCE_GROUP"
+  exit 0
+fi
+
+set -e
+set -u
+
+: "${ZONE:=us-central1-a}"
+
+name="$(gcloud compute instance-groups managed describe --zone="${ZONE}" "${1}" --format='value(versions[0].instanceTemplate)')"
+gcloud compute instance-groups managed rolling-action start-update --zone="${ZONE}" "${1}" --version=template="${name}"


### PR DESCRIPTION
This terraform module manages a MIG of compute instances running an HTTP
forward proxy.  The intended use case is to direct traffic through an
interconnect from an on-prem data center.