### PR TITLE
Block access to metadata through the proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+v1.0.2 - 2021-07-26
+===
+
+ * Block access to metadata service
+
+v1.0.1 - 2021-07-26
+===
+
+ * Use `allow-health-checks` tag in accordance with docs
+
+v1.0.0 - 2021-07-26
+===
+
+ * Initial release with HTTP Forward Proxy example

--- a/examples/proxy/files/startup.sh
+++ b/examples/proxy/files/startup.sh
@@ -9,6 +9,11 @@ cat <<EOF >/etc/apache2/mods-available/proxy.conf
 <IfModule mod_proxy.c>
 Listen 3128
 ProxyRequests On
+
+# Block access to the metadata server, otherwise clients could access workload
+# identity (service account) credentials
+ProxyBlock metadata.google.internal metadata.google metadata 169.254.169.254
+
 <Proxy *>
   AddDefaultCharset off
   # This is an open proxy.  Control access with the VPC firewall.


### PR DESCRIPTION
Block access to the instance metadata service via the forward proxy to prevent
clients from reading service account credentials.
