### PR TITLE
Pass tags through top level module

### DIFF
--- a/modules/55_auto/main.tf
+++ b/modules/55_auto/main.tf
@@ -40,6 +40,7 @@ module "mig" {
   name_prefix = var.name_prefix
   region      = var.region
   zones       = local.zones
+  tags        = var.tags
 
   nic0_project = var.project_id
   nic0_network = var.nic0_network

--- a/modules/55_auto/variables.tf
+++ b/modules/55_auto/variables.tf
@@ -127,3 +127,9 @@ variable "health_check_path" {
   type        = string
   default     = "/healthz"
 }
+
+variable "tags" {
+  description = "Additional network tags added to instances.  Useful for opening VPC firewall access.  TCP Port 80 must be allowed into nic0 for health checking to work."
+  type        = list(string)
+  default     = ["allow-health-checks"]
+}


### PR DESCRIPTION
Without this patch consumers cannot specify tags of the instances.  This
patch enables tags to be passed through the high level MIG module to the
lower level instance group manager module.

The intent is to allow the SSH tag.
