### PR TITLE
Run iperf server on the proxy on port 5001

### DIFF
--- a/examples/proxy/files/startup.sh
+++ b/examples/proxy/files/startup.sh
@@ -106,6 +106,59 @@ EOF
   systemctl restart google-cloud-ops-agent
 fi
 
-## Ops Agent apache2 configuration: This isn't ready because it doesn't result in structured logs.
+setup_iperf2_server() {
+  local svcfile
+  apt install -y -qq iperf
+  svcfile="$(mktemp)"
+  cat <<EOF>"$svcfile"
+[Unit]
+Description=iperf server
+After=network-online.target
+Wants=network-online.target
 
-# Ops Agent configuration
+[Service]
+Type=simple
+ExecStart=/usr/bin/iperf --server --interval 5
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  install -m 0644 -o 0 -g 0 "$svcfile" /etc/systemd/system/iperf2-server.service
+  systemctl daemon-reload
+  systemctl start iperf2-server
+  systemctl enable iperf2-server
+}
+
+setup_iperf3_server() {
+  local svcfile
+  apt install -y -qq iperf3
+  svcfile="$(mktemp)"
+  cat <<EOF>"$svcfile"
+[Unit]
+Description=iperf3 server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/iperf3 --server --interval 5
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  install -m 0644 -o 0 -g 0 "$svcfile" /etc/systemd/system/iperf3-server.service
+  systemctl daemon-reload
+  systemctl start iperf3-server
+  systemctl enable iperf3-server
+}
+
+
+if ! [[ -e /etc/systemd/system/iperf2-server.service ]]; then
+  setup_iperf2_server
+fi
+
+if ! [[ -e /etc/systemd/system/iperf3-server.service ]]; then
+  setup_iperf3_server
+fi


### PR DESCRIPTION
To measure latencies to determine which proxy cluster to use from a
given on-prem location.

```bash
sudo systemctl status iperf2-server
```

```txt
● iperf2-server.service - iperf server
   Loaded: loaded (/etc/systemd/system/iperf2-server.service; enabled; vendor preset: enabled)
   Active: active (running) since Tue 2021-08-31 21:11:42 UTC; 35s ago
 Main PID: 4210 (iperf)
    Tasks: 3 (limit: 2067)
   Memory: 436.0K
   CGroup: /system.slice/iperf2-server.service
           └─4210 /usr/bin/iperf --server --interval 5

Aug 31 21:11:42 proxy-0fhd systemd[1]: Started iperf server.
Aug 31 21:11:42 proxy-0fhd iperf[4210]: ------------------------------------------------------------
Aug 31 21:11:42 proxy-0fhd iperf[4210]: Server listening on TCP port 5001
Aug 31 21:11:42 proxy-0fhd iperf[4210]: TCP window size:  128 KByte (default)
Aug 31 21:11:42 proxy-0fhd iperf[4210]: ------------------------------------------------------------
```
